### PR TITLE
Prototype destroy

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :set_prototype, only: :show
+  before_action :set_prototype, only: [:show, :destroy]
 
   def index
     @prototypes = Prototype.order('created_at DESC').includes(:user).page(params[:page]).per(9)
@@ -20,8 +20,8 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
-    prototype = Prototype.find(params[:id])
-    prototype.destroy if prototype.user_id == current_user.id
+    @prototype.destroy if @prototype.user_id == current_user.id
+    redirect_to :root, notice: "削除完了しました"
   end
 
   def show

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -13,7 +13,7 @@
             = link_to "#{@prototype.user.name}", user_path(@prototype.user)
             .degree
               = @prototype.user.position
-            = if user_signed_in? && current_user.id == @prototype.user_id
+            - if user_signed_in? && current_user.id == @prototype.user_id
               %ul.proto-user__btn
                 %li.edit
                   = link_to("Edit", "#")

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -13,12 +13,12 @@
             = link_to "#{@prototype.user.name}", user_path(@prototype.user)
             .degree
               = @prototype.user.position
-            = if user_signed_in? && current_user.id == prototype.user_id
+            = if user_signed_in? && current_user.id == @prototype.user_id
               %ul.proto-user__btn
                 %li.edit
                   = link_to("Edit", "#")
                 %li.delete
-                  = link_to("Delete", "/prototype/#{prototyape.id}", method: :delete)
+                  = link_to("Delete", "/prototype/#{@prototype.id}", method: :delete)
   .row
     .col-md-9.image-box
       = image_tag(@prototype.set_main_thumbnail.large, class: 'img-responsive img-size-fix', style: "margin: 0 auto;")

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -18,7 +18,7 @@
                 %li.edit
                   = link_to("Edit", "#")
                 %li.delete
-                  = link_to("Delete", "/prototype/#{@prototype.id}", method: :delete)
+                  = link_to("Delete", "/prototypes/#{@prototype.id}", method: :delete)
   .row
     .col-md-9.image-box
       = image_tag(@prototype.set_main_thumbnail.large, class: 'img-responsive img-size-fix', style: "margin: 0 auto;")


### PR DESCRIPTION
# 内容
削除機能のバグ解決。
削除後の挙動は、redirect_toでroot先（index）に戻り、
アラート機能でindex上部に「削除完了しました」を表示する。